### PR TITLE
Added link to DuckDuckGo About page in footer

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -36,6 +36,7 @@
                     {{#if @blog.twitter}}<a href="{{twitter_url @blog.twitter}}" target="_blank" rel="noopener">Twitter</a>{{/if}}
                     <a href="https://www.reddit.com/r/duckduckgo/" target="_blank" rel="noopener">Reddit</a>
                     <a href="https://duckduckgo.com/newsletter" target="_blank" rel="noopener">Privacy Crash Course</a>
+                    <a href="https://duckduckgo.com/about" target="_blank">About DuckDuckGo</a>
                 </nav>
             </div>
         </footer>


### PR DESCRIPTION
This should help people looking for more info about DuckDuckGo and reduce direct enquiries.

Note: I haven't added the `rel="noopener"` attribute as I don't think we need that for links to our own properties.