### PR TITLE
Switch language from "Filed under" to "Last updated" on pages.

### DIFF
--- a/page.hbs
+++ b/page.hbs
@@ -19,7 +19,7 @@ into the {body} of the default.hbs template --}}
             <header class="post-full-header">
                 <h1 class="post-full-title">{{title}}</h1>
                 <section class="post-full-meta-filed">
-                    <span>Filed under {{#primary_tag}}<a href="{{url}}">{{name}}</a>{{/primary_tag}} on </span>
+                    <span>Last updated on </span>
                     <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
                 </section>
             </header>


### PR DESCRIPTION
Static pages (like this one https://d4c11fe1.ngrok.io/what-is-the-revenue-generation-model-for-duckduckgo/) would have "Last updated on ..." for the dates to indicate update date instead of the normal publishing date.

<img width="1680" alt="screen shot 2019-01-09 at 12 21 40 pm" src="https://user-images.githubusercontent.com/81969/50916558-6ac3f880-1409-11e9-93cb-1d4c92eb7ab8.png">
