### PR TITLE
Remove dates from articles with the tag "DuckDuckGo Q&A"

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -22,8 +22,8 @@ into the {body} of the default.hbs template --}}
                 <section class="post-full-meta-filed">
                     {{#primary_tag}}
                         {{^has slug="duckduckgo-q-a"}}
-                        	<span>Filed under <a href="{{url}}">{{name}}</a> on </span>
-                        	<time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
+                            <span>Filed under <a href="{{url}}">{{name}}</a> on </span>
+                            <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
                         {{else}}
                             <span>Filed under <a href="{{url}}">{{name}}</a></span>
                         {{/has}}

--- a/post.hbs
+++ b/post.hbs
@@ -20,8 +20,14 @@ into the {body} of the default.hbs template --}}
             <header class="post-full-header">
                 <h1 class="post-full-title">{{title}}</h1>
                 <section class="post-full-meta-filed">
-                    <span>Filed under {{#primary_tag}}<a href="{{url}}">{{name}}</a>{{/primary_tag}} on </span>
-                    <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
+                    {{#primary_tag}}
+                        {{^has slug="duckduckgo-q-a"}}
+                        	<span>Filed under <a href="{{url}}">{{name}}</a> on </span>
+                        	<time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
+                        {{else}}
+                            <span>Filed under <a href="{{url}}">{{name}}</a></span>
+                        {{/has}}
+                    {{/primary_tag}}    
                 </section>
             </header>
 


### PR DESCRIPTION
Use the `{{#has}}` helper (https://ghost.org/docs/api/v3/handlebars-themes/helpers/has/) to 
remove dates from the posts with the tag "DuckDuckGo Q&A".

**Posts with the "Q&A" tag:**
<img width="1194" alt="Posts w: Q A tag" src="https://user-images.githubusercontent.com/81969/83185711-60d39000-a0f9-11ea-8002-015c7b6efcf5.png">

**Posts without the "Q&A" tag:**
<img width="1194" alt="Other Posts" src="https://user-images.githubusercontent.com/81969/83185785-806ab880-a0f9-11ea-9a90-3fdcc0093f83.png">

