### PR TITLE
Fix Post Dates: Only wrap <a> tag in {{#primary_tag}}

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -20,14 +20,12 @@ into the {body} of the default.hbs template --}}
             <header class="post-full-header">
                 <h1 class="post-full-title">{{title}}</h1>
                 <section class="post-full-meta-filed">
-                    {{#primary_tag}}
-                        {{^has slug="duckduckgo-q-a"}}
-                            <span>Filed under <a href="{{url}}">{{name}}</a> on </span>
-                            <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
-                        {{else}}
-                            <span>Filed under <a href="{{url}}">{{name}}</a></span>
-                        {{/has}}
-                    {{/primary_tag}}    
+                    {{#has slug="duckduckgo-q-a"}}
+                        <span>Filed under {{#primary_tag}}<a href="{{url}}">{{name}}</a>{{/primary_tag}}</span>
+                    {{else}}
+                        <span>Filed under {{#primary_tag}}<a href="{{url}}">{{name}}</a>{{/primary_tag}} on </span>
+                        <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
+                    {{/has}}
                 </section>
             </header>
 


### PR DESCRIPTION
Fixes a bug introduced by wrapping the `{date}` tag inside a `{#primary_tag}` where the context is different.

## Steps to test
- Refer to internal docs on how to install ghost + the casper theme
- CD into theme dir and checkout this branch
- `gulp`
- Export blog JSON from live blog
- Import blog JSON to local dev instance
    - This requires creating a (throwaway) ghost admin account on your local dev instance 
- Visit http://localhost:2368/duckduckgo-tracker-blocker-in-vivaldi/
- Compare to http://spreadprivacy.com/duckduckgo-tracker-blocker-in-vivaldi/
    - Locale instance should show older date, and production should show today's date