### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Casper – Ghost Default Theme
+
+## Cursor Cloud specific instructions
+
+### Node.js version requirement
+
+This project uses **Gulp 3.9.1** which depends on the `natives` package. It requires **Node.js 8.x** (specifically v8.17.0). Node 10+ will fail with `internalBinding is not defined` and Node 12+ will fail with `primordials is not defined`.
+
+The environment uses `nvm` with Node 8.17.0 set as default.
+
+### Development workflow
+
+- `yarn dev` — runs `gulp` default task which compiles CSS/JS, starts livereload on port 1234, and watches `assets/css/` and `assets/js/` for changes.
+- `yarn zip` — packages the theme into `dist/casper.zip` for upload to a Ghost instance.
+- CSS is compiled with PostCSS (autoprefixer, custom properties, color function, cssnano).
+- JS is minified via `gulp-minify`.
+
+### Running the theme
+
+This is a Ghost CMS theme (Handlebars templates), not a standalone application. To see it render, it must be installed in a running Ghost instance. For development purposes, `yarn dev` is sufficient to validate asset compilation and the watch/livereload cycle.
+
+### No lint tool configured
+
+This project does not have a dedicated linter (no ESLint, Stylelint, or similar). The build (`yarn dev` or `yarn zip`) is the primary correctness check.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for developing with this codebase.

## Key details for future agents

- **Node.js 8.17.0** is required (Gulp 3.9.1 + `natives` package incompatible with Node 10+)
- `yarn dev` compiles CSS/JS assets and starts livereload watcher on port 1234
- `yarn zip` packages the theme for deployment
- No dedicated linter is configured; the build is the primary correctness check
- This is a Ghost CMS Handlebars theme, not a standalone app

## Build evidence

[build_output.log](https://cursor.com/agents/bc-532a4078-6583-46ef-ae5a-a5a12632a725/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-532a4078-6583-46ef-ae5a-a5a12632a725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-532a4078-6583-46ef-ae5a-a5a12632a725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

