### PR TITLE
Add release build workflow and bump to 2.5.0

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,64 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_exists: ${{ steps.check_release.outputs.exists }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release already exists
+        id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js 8.17.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: '8.17.0'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Build theme zip
+        run: yarn zip
+
+      - name: Rename zip with version
+        run: cp dist/casper.zip "dist/casper-v${{ steps.version.outputs.version }}.zip"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: casper-v${{ steps.version.outputs.version }}
+          path: dist/casper-v${{ steps.version.outputs.version }}.zip
+          if-no-files-found: error
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            "dist/casper-v${{ steps.version.outputs.version }}.zip" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
   push:
     branches: [master]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -54,7 +55,7 @@ jobs:
           if-no-files-found: error
 
       - name: Create GitHub Release
-        if: steps.check_release.outputs.exists == 'false'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.check_release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "casper",
     "description": "The default personal blogging theme for Ghost. Beautiful, minimal and responsive.",
     "demo": "https://demo.ghost.io",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "engines": {
         "ghost": ">=5.0.0"
     },


### PR DESCRIPTION
## Summary
Adds an automated build process so we get a freshly built `casper.zip` to upload to Ghost every time a PR merges to master, and bumps the theme version to 2.5.0.

## Changes
- New workflow `.github/workflows/build-and-release.yml`:
  - Triggers on every push to `master` and on manual `workflow_dispatch`.
  - Pins to Node 8.17.0 (Gulp 3.9.1 / `natives` constraint, per `AGENTS.md`).
  - Runs `yarn install --frozen-lockfile --ignore-engines` and `yarn zip`.
  - Always uploads `casper-v<version>.zip` as a workflow artifact (downloadable from the Actions run for ~90 days).
  - Creates a GitHub Release tagged `v<version>` with the zip attached **only** when the version in `package.json` does not already have a release. So contributors bump the version when they want a new release, and the workflow handles the rest.
- `package.json`: `2.4.0` -> `2.5.0`.

## Why
- No CI build today; the zip has to be produced by hand on a machine with Node 8.
- Last release tag is `2.3.4`; since then several visible changes have shipped (#41 sidebar revamp, #45 community link, #47 sidebar redesign to match duckduckgo.com, plus #38 Ghost v5 compatibility). Per semver that's a minor bump, so `2.5.0` rather than `2.4.1`.

## How to verify
- After merging, the `Build and Release` workflow should run on `master`.
- Confirm the workflow:
  - Completes successfully on the `master` push.
  - Uploads a `casper-v2.5.0` artifact on the Actions run.
  - Creates a `v2.5.0` GitHub Release with `casper-v2.5.0.zip` attached.
- Future PRs that don't bump the version will still produce a workflow artifact, but won't create a duplicate release.
- Not tested locally: `yarn zip` was not run in this branch — the workflow itself is the verification path because Node 8.17.0 is awkward to reproduce outside the documented Cursor Cloud env.

## What to look for
- Whether `actions/setup-node@v3` reliably installs Node 8.17.0 on `ubuntu-latest` — Node 8 is EOL and may eventually be dropped. If it breaks, fallback options: nvm install in a script step, or a Node 8 container.
- `--ignore-engines` is set on `yarn install` because several deps declare engines that exclude Node 8.x; this matches local behaviour.
- Release notes are `--generate-notes` (auto from commits since previous tag). If the auto notes look noisy, we can switch to a hand-curated body.
- The workflow has `permissions: contents: write` so the `GITHUB_TOKEN` can create the release. No other scopes needed.

## Notes
- Future release flow: open a PR that bumps `version` in `package.json` -> merge -> workflow creates the tagged release with the zip attached.
- If we ever want a per-PR preview zip (before merge), we can add a `pull_request` trigger that only uploads the artifact and skips the release step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated GitHub Actions release pipeline with `contents: write` permissions and GitHub Release creation, which can affect repo releases/tags if misconfigured. Build itself is straightforward but relies on EOL Node 8 on `ubuntu-latest`, which may be brittle.
> 
> **Overview**
> Adds a new `Build and Release` GitHub Actions workflow that installs Node `8.17.0`, runs `yarn install` + `yarn zip`, uploads a versioned `casper-v<version>.zip` artifact, and **creates a GitHub Release `v<version>`** on pushes to `master` when that tag doesn’t already exist.
> 
> Bumps `package.json` version from `2.4.0` to `2.5.0` to drive the release/tag and artifact naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768cec967981921ce493f65ec377893dc7a94361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->